### PR TITLE
Dust Generation Alternate

### DIFF
--- a/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/ClayGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -11,24 +12,32 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.rafacost3d.usrg.setup.Config;
 
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class ClayGeneratorTile extends TileEntity implements ITickableTileEntity {
 
     private ItemStackHandler handler;
-
+    
     public ClayGeneratorTile() {
         super(CLAYGENERATOR_TILE);
     }
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.CLAY, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.CLAY_BALL, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.CLAY, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/GlowstoneGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class GlowstoneGeneratorTile extends TileEntity implements ITickableTileE
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.GLOWSTONE_DUST, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.GLOWSTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 //
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/QuartzGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class QuartzGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class QuartzGeneratorTile extends TileEntity implements ITickableTileEnti
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.QUARTZ, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.QUARTZ_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/RedstoneGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class RedstoneGeneratorTile extends TileEntity implements ITickableTileEn
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.REDSTONE, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.REDSTONE_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
+++ b/src/main/java/com/rafacost3d/usrg/blocks/SnowGeneratorTile.java
@@ -2,6 +2,7 @@ package com.rafacost3d.usrg.blocks;
 
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +16,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.rafacost3d.usrg.setup.Config;
+
 import static com.rafacost3d.usrg.blocks.ModBlocks.*;
 
 public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity {
@@ -27,8 +30,13 @@ public class SnowGeneratorTile extends TileEntity implements ITickableTileEntity
 
     @Override
     public void tick() {
-        ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
-        ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	if (Config.GENERATE_DUST.get()) {
+            ItemStack stack = new ItemStack(Items.SNOWBALL, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	} else {
+            ItemStack stack = new ItemStack(Blocks.SNOW_BLOCK, 1);
+            ItemHandlerHelper.insertItemStacked(getHandler(),stack, false);
+    	}
     }
 
 //    @Override

--- a/src/main/java/com/rafacost3d/usrg/setup/Config.java
+++ b/src/main/java/com/rafacost3d/usrg/setup/Config.java
@@ -25,13 +25,14 @@ public class Config {
     public static ForgeConfigSpec COMMON_CONFIG;
     public static ForgeConfigSpec CLIENT_CONFIG;
 
+    public static ForgeConfigSpec.BooleanValue GENERATE_DUST;
     public static ForgeConfigSpec.IntValue BLOCK_PER_TICK;
-    public static ForgeConfigSpec.IntValue ORE_PER_TICK;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> ORE_GENERATOR_ITEMS;
 
     static {
         COMMON_BUILDER.comment("General Settings").push(CATEGORY_GENERAL);
-        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between Block Generated").defineInRange("blocks_per_tick", 40, 1, 2000);
+        GENERATE_DUST = COMMON_BUILDER.comment("Clay, Glowstone, Quartz, Redstone and Snow Generators will generate dust items, not blocks.").define("generate_dust", false);
+        BLOCK_PER_TICK = COMMON_BUILDER.comment("Ticks between each generation cycle.").defineInRange("blocks_per_tick", 40, 1, 2000);
         COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("OreGenerator Settings").push(CATEGORY_OREGEN);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -45,7 +45,7 @@ displayName="Ultimate Skyblock Resource Generator" #mandatory
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 The Ultimate Cobble, Gravel, Sand, Dirt, Grass, Mycelium, Obsidian, Ice and Snow Generator.
-If Ex Nihilo: Sequentia installed, includes Dust Generator.
+If Ex Nihilo: Sequentia installed, includes Dust, Crushed Endstone and Crushed Netherrack Generator.
 '''
 
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.


### PR DESCRIPTION
1. Added config setting (GENERATE_DUST, True/False).
2. Updated Clay, Glowstone, Quartz, Redstone and Snow Generators to create dust item is new config setting is True, otherwise will generate the block.